### PR TITLE
Added local storage for ORCID claims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ install:
   - "pip install -r requirements.txt"
   - "pip install -r dev-requirements.txt"
 
+addons:
+  postgresql: "9.6"
+
+before_script:
+  - psql -c 'create database test;' -U postgres
+
 script:
   - "py.test"
 

--- a/alembic/versions/07c3fe07309c_create_profile_table.py
+++ b/alembic/versions/07c3fe07309c_create_profile_table.py
@@ -1,0 +1,34 @@
+"""Create profile table
+
+Revision ID: 07c3fe07309c
+Revises: 386337178a2f
+Create Date: 2018-08-24 16:52:50.938617
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '07c3fe07309c'
+down_revision = '386337178a2f'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import datetime
+
+
+def upgrade():
+    #with app.app_context() as c:
+    #   db.session.add(Model())
+    #   db.session.commit()
+
+    op.create_table('profile',
+                    sa.Column('orcid_id', sa.String(length=255), nullable=False),
+                    sa.Column('created', sa.DateTime(), nullable=True, default=datetime.datetime.utcnow),
+                    sa.Column('updated', sa.DateTime(), nullable=True, default=datetime.datetime.utcnow),
+                    sa.Column('bibcode', postgresql.JSON(), nullable=True),
+                    sa.PrimaryKeyConstraint('orcid_id')
+                    )
+
+
+def downgrade():
+    op.drop_table('profile')

--- a/alembic/versions/07c3fe07309c_create_profile_table.py
+++ b/alembic/versions/07c3fe07309c_create_profile_table.py
@@ -14,6 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 import datetime
+from adsmutils import UTCDateTime, get_date
 
 
 def upgrade():
@@ -23,8 +24,8 @@ def upgrade():
 
     op.create_table('profile',
                     sa.Column('orcid_id', sa.String(length=255), nullable=False),
-                    sa.Column('created', sa.DateTime(), nullable=True, default=datetime.datetime.utcnow),
-                    sa.Column('updated', sa.DateTime(), nullable=True, default=datetime.datetime.utcnow),
+                    sa.Column('created', UTCDateTime, nullable=True, default=get_date),
+                    sa.Column('updated', UTCDateTime, nullable=True, default=get_date),
                     sa.Column('bibcode', postgresql.JSON(), nullable=True),
                     sa.PrimaryKeyConstraint('orcid_id')
                     )

--- a/config.py
+++ b/config.py
@@ -8,5 +8,5 @@ ORCID_API_ENDPOINT = 'https://api.sandbox.orcid.org/v2.0'
 ORCID_CLIENT_ID = 'APP-P5ANJTQRRTMA6GXZ'
 ORCID_CLIENT_SECRET = '989e54c8-7093-4128-935f-30c19ed9158c'
 
-SQLALCHEMY_DATABASE_URI = 'sqlite:///'
+SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://postgres:postgres@localhost:5432/test_orcid_service"
 SQLALCHEMY_ECHO = False

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ httpretty==0.8.10
 mock==1.3.0
 coverage==4.0.1
 pytest-cov==2.2.0
+testing.postgresql==1.2.1

--- a/orcid_service/models.py
+++ b/orcid_service/models.py
@@ -6,10 +6,65 @@
     Models for the users (users) of AdsWS
 """
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.mutable import Mutable
+from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy import Column, String, TIMESTAMP, Text
 import json
 
 Base = declarative_base()
+
+class MutableDict(Mutable, dict):
+    """
+    By default, SQLAlchemy only tracks changes of the value itself, which works
+    "as expected" for simple values, such as ints and strings, but not dicts.
+    http://stackoverflow.com/questions/25300447/
+    using-list-on-postgresql-json-type-with-sqlalchemy
+    """
+
+    @classmethod
+    def coerce(cls, key, value):
+        """
+        Convert plain dictionaries to MutableDict.
+        """
+        if not isinstance(value, MutableDict):
+            if isinstance(value, dict):
+                return MutableDict(value)
+
+            # this call will raise ValueError
+            return Mutable.coerce(key, value)
+        else:
+            return value
+
+    def __setitem__(self, key, value):
+        """
+        Detect dictionary set events and emit change events.
+        """
+        dict.__setitem__(self, key, value)
+        self.changed()
+
+    def __delitem__(self, key):
+        """
+        Detect dictionary del events and emit change events.
+        """
+        dict.__delitem__(self, key)
+        self.changed()
+
+    def setdefault(self, key, value):
+        """
+        Detect dictionary setdefault events and emit change events
+        """
+        dict.setdefault(self, key, value)
+        self.changed()
+
+    def pop(self, key, default):
+        """
+        Detect dictionary pop events and emit change events
+        :param key: key to pop
+        :param default: default if key does not exist
+        :return: the item under the given key
+        """
+        dict.pop(self, key, default)
+        self.changed()
 
 class User(Base):
     __tablename__ = 'users'
@@ -31,3 +86,97 @@ class User(Base):
             'profile': self.profile and json.loads(self.profile) or None,
             'info': self.info and json.loads(self.info) or None
         }
+
+class Profile(Base):
+    __tablename__ = 'profile'
+
+    orcid_id = Column(String(255), primary_key=True)
+    created = Column(TIMESTAMP)
+    updated = Column(TIMESTAMP)
+    bibcode = Column(MutableDict.as_mutable(JSON), default={})
+
+    bib_status = ['verified', 'pending', 'rejected']
+    nonbib_status = ['not in ADS']
+
+    keys = ['status', 'title', 'pubyear', 'pubmonth']
+
+    def get_bibcodes(self):
+        """
+        Returns the bibcodes of the ORCID profile
+        """
+        bibcodes, statuses = self.find_nested(self.bibcode, 'status', self.bib_status)
+        return bibcodes, statuses
+
+    def get_non_bibcodes(self):
+        """
+        Returns the non-ADS records of the ORCID profile
+        """
+        non_bibcodes, status = self.find_nested(self.bibcode, 'status', self.nonbib_status)
+        return non_bibcodes
+
+    def add_records(self, records):
+        """
+        Adds a record to the bibcode field, first making sure it has the appropriate nested dict
+        :param records: dict of dicts of bibcodes and non-bibcodes
+        """
+        if not self.bibcode:
+            self.bibcode = {}
+        for r in records:
+            for k in self.keys:
+                tmp = records[r].setdefault(k, None)
+        self.bibcode.update(records)
+
+    def remove_bibcodes(self, bibcodes):
+        """
+        Removes a bibcode(s) from the bibcode field.
+        Given the way in which bibcodes are stored may change, it seems simpler
+        to keep the method of adding/removing in a small wrapper so that only
+        one location needs to be modified (or YAGNI?).
+        :param bibcodes: list of bibcodes
+        """
+        [self.bibcode.pop(key, None) for key in bibcodes]
+
+    def get_nested(self, dictionary, nested_key):
+        """Get all values from the nested dictionary for a given nested key"""
+        keys = dictionary.keys()
+        vals = []
+        for key in keys:
+            vals.append(dictionary[key].setdefault(nested_key, None))
+
+        return vals
+
+    def find_nested(self, dictionary, nested_key, nested_value):
+        """Get all top-level keys from a nested dictionary for a given list of nested values
+         belonging to a given nested key
+         :param dictionary - nested dictionary to search; searches one level deep
+         :param nested_key - key within nested dictionary to search for
+         :param nested_value - list (or string or number) of acceptable values to search for within the
+            given nested_key
+         :return good_keys - list of top-level keys with a matching nested value to the given nested key
+         :return good_values - list of the value (from nested_value) retrieved
+         """
+        if type(nested_value) is not list:
+            nested_value = [nested_value]
+
+        keys = dictionary.keys()
+        good_keys = []
+        good_values = []
+        for key in keys:
+            if dictionary[key].get(nested_key,'') in nested_value:
+                good_keys.append(key)
+                good_values.append(dictionary[key].get(nested_key))
+
+        return good_keys, good_values
+
+    def update_status(self, keys, status):
+        """
+        Update the status for a given key or keys
+        :param keys: str or list
+        :param status: str
+        :return: None
+        """
+        if type(keys) is not list:
+            keys = [keys]
+
+        for key in keys:
+            self.bibcode[key]['status'] = status

--- a/orcid_service/models.py
+++ b/orcid_service/models.py
@@ -35,27 +35,6 @@ class MutableDict(Mutable, dict):
         else:
             return value
 
-    def __setitem__(self, key, value):
-        """
-        Detect dictionary set events and emit change events.
-        """
-        dict.__setitem__(self, key, value)
-        self.changed()
-
-    def __delitem__(self, key):
-        """
-        Detect dictionary del events and emit change events.
-        """
-        dict.__delitem__(self, key)
-        self.changed()
-
-    def setdefault(self, key, value):
-        """
-        Detect dictionary setdefault events and emit change events
-        """
-        dict.setdefault(self, key, value)
-        self.changed()
-
     def pop(self, key, default):
         """
         Detect dictionary pop events and emit change events
@@ -179,4 +158,5 @@ class Profile(Base):
             keys = [keys]
 
         for key in keys:
-            self.bibcode[key]['status'] = status
+            if self.bibcode.get(key):
+                self.bibcode[key]['status'] = status

--- a/orcid_service/tests/base.py
+++ b/orcid_service/tests/base.py
@@ -1,0 +1,51 @@
+from flask.ext.testing import TestCase
+import testing.postgresql
+from orcid_service.models import Base
+
+
+class TestCaseDatabase(TestCase):
+    """
+    Base test class for when databases are being used.
+    """
+    postgresql_url_dict = {
+        'port': 1234,
+        'host': '127.0.0.1',
+        'user': 'postgres',
+        'database': 'test'
+    }
+
+    postgresql_url = 'postgresql://{user}@{host}:{port}/{database}' \
+        .format(
+        user=postgresql_url_dict['user'],
+        host=postgresql_url_dict['host'],
+        port=postgresql_url_dict['port'],
+        database=postgresql_url_dict['database']
+    )
+
+    def create_app(self):
+        '''Start the wsgi application'''
+        from orcid_service import app
+        a = app.create_app(**{
+            'SQLALCHEMY_DATABASE_URI': self.postgresql_url,
+            'SQLALCHEMY_ECHO': False,
+            'TESTING': True,
+            'PROPAGATE_EXCEPTIONS': True,
+            'TRAP_BAD_REQUEST_ERRORS': True
+        })
+        return a
+
+    @classmethod
+    def setUpClass(cls):
+        cls.postgresql = \
+            testing.postgresql.Postgresql(**cls.postgresql_url_dict)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.postgresql.stop()
+
+    def setUp(self):
+        Base.metadata.create_all(bind=self.app.db.engine)
+
+    def tearDown(self):
+        self.app.db.session.remove()
+        self.app.db.drop_all()

--- a/orcid_service/tests/stubdata/orcid_profile_api_v2.py
+++ b/orcid_service/tests/stubdata/orcid_profile_api_v2.py
@@ -686,6 +686,155 @@ data = {
                             "display-index": "1"
                         }
                     ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1522444762829
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1088/0004-637X/810/2/149",
+                                "external-id-url": {
+                                    "value": "http://dx.doi.org/10.1088/0004-637X/810/2/149"
+                                },
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2015ApJ...810..149L",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "other-id",
+                                "external-id-value": "2127038",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 31358145,
+                            "created-date": {
+                                "value": 1490598610415
+                            },
+                            "last-modified-date": {
+                                "value": 1520448612209
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://orcid.org/client/0000-0001-9884-1913",
+                                    "path": "0000-0001-9884-1913",
+                                    "host": "orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "Crossref"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "HST/WFC3 OBSERVATIONS OF AN OFF-NUCLEAR SUPERBUBBLE IN ARP 220"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1088/0004-637X/810/2/149",
+                                        "external-id-url": {
+                                            "value": "http://dx.doi.org/10.1088/0004-637X/810/2/149"
+                                        },
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2015"
+                                },
+                                "month": {
+                                    "value": "09"
+                                },
+                                "day": {
+                                    "value": "09"
+                                },
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0002-8130-1440/work/31358145",
+                            "display-index": "0"
+                        },
+                        {
+                            "put-code": 38497466,
+                            "created-date": {
+                                "value": 1510265009916
+                            },
+                            "last-modified-date": {
+                                "value": 1522444762829
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://orcid.org/client/APP-BA5POB6F5D7CTHX2",
+                                    "path": "APP-BA5POB6F5D7CTHX2",
+                                    "host": "orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "HST/WFC3 Observations of an Off-nuclear Superbubble in Arp 220"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2015ApJ...810..149L",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "other-id",
+                                        "external-id-value": "2127038",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1088/0004-637X/810/2/149",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2015"
+                                },
+                                "month": {
+                                    "value": "09"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0002-8130-1440/work/38497466",
+                            "display-index": "0"
+                        }
+                    ]
                 }
             ],
             "path": "/0000-0001-8868-9743/works"

--- a/orcid_service/tests/stubdata/orcid_profile_api_v2.py
+++ b/orcid_service/tests/stubdata/orcid_profile_api_v2.py
@@ -1,0 +1,696 @@
+data = {
+    "orcid-identifier": {
+        "uri": "http://sandbox.orcid.org/0000-0001-8868-9743",
+        "path": "0000-0001-8868-9743",
+        "host": "sandbox.orcid.org"
+    },
+    "preferences": {
+        "locale": "EN"
+    },
+    "history": {
+        "creation-method": "MEMBER_REFERRED",
+        "completion-date": None,
+        "submission-date": {
+            "value": 1523547463758
+        },
+        "last-modified-date": {
+            "value": 1534367410146
+        },
+        "claimed": True,
+        "source": None,
+        "deactivation-date": None,
+        "verified-email": True,
+        "verified-primary-email": True
+    },
+    "person": {
+        "last-modified-date": None,
+        "name": {
+            "created-date": {
+                "value": 1523547463758
+            },
+            "last-modified-date": {
+                "value": 1523547463983
+            },
+            "given-names": {
+                "value": "Cecilia"
+            },
+            "family-name": {
+                "value": "Payne"
+            },
+            "credit-name": None,
+            "source": None,
+            "visibility": "PUBLIC",
+            "path": "0000-0001-8868-9743"
+        },
+        "other-names": {
+            "last-modified-date": None,
+            "other-name": [],
+            "path": "/0000-0001-8868-9743/other-names"
+        },
+        "biography": None,
+        "researcher-urls": {
+            "last-modified-date": None,
+            "researcher-url": [],
+            "path": "/0000-0001-8868-9743/researcher-urls"
+        },
+        "emails": {
+            "last-modified-date": None,
+            "email": [],
+            "path": "/0000-0001-8868-9743/email"
+        },
+        "addresses": {
+            "last-modified-date": None,
+            "address": [],
+            "path": "/0000-0001-8868-9743/address"
+        },
+        "keywords": {
+            "last-modified-date": None,
+            "keyword": [],
+            "path": "/0000-0001-8868-9743/keywords"
+        },
+        "external-identifiers": {
+            "last-modified-date": None,
+            "external-identifier": [],
+            "path": "/0000-0001-8868-9743/external-identifiers"
+        },
+        "path": "/0000-0001-8868-9743/person"
+    },
+    "activities-summary": {
+        "last-modified-date": {
+            "value": 1534367390880
+        },
+        "educations": {
+            "last-modified-date": None,
+            "education-summary": [],
+            "path": "/0000-0001-8868-9743/educations"
+        },
+        "employments": {
+            "last-modified-date": None,
+            "employment-summary": [],
+            "path": "/0000-0001-8868-9743/employments"
+        },
+        "fundings": {
+            "last-modified-date": None,
+            "group": [],
+            "path": "/0000-0001-8868-9743/fundings"
+        },
+        "peer-reviews": {
+            "last-modified-date": None,
+            "group": [],
+            "path": "/0000-0001-8868-9743/peer-reviews"
+        },
+        "works": {
+            "last-modified-date": {
+                "value": 1534367390880
+            },
+            "group": [
+                {
+                    "last-modified-date": {
+                        "value": 1523547712899
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1038/s41598-018-20787-2",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2018NatSR...8.2398L",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 922001,
+                            "created-date": {
+                                "value": 1523547712899
+                            },
+                            "last-modified-date": {
+                                "value": 1523547712899
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "A novel small deletion in the NHS gene associated with Nance-Horan syndrome"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2018NatSR...8.2398L",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1038/s41598-018-20787-2",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/922001",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1523547713378
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2018NatCo...9..447Z",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1038/s41467-018-02847-3",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 922043,
+                            "created-date": {
+                                "value": 1523547713378
+                            },
+                            "last-modified-date": {
+                                "value": 1523547713378
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "A peculiar low-luminosity short gamma-ray burst from a double neutron star merger progenitor"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2018NatCo...9..447Z",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1038/s41467-018-02847-3",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/922043",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1523547712732
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2018RvMPP...2....2D",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1007/s41614-018-0014-9",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 921989,
+                            "created-date": {
+                                "value": 1523547712732
+                            },
+                            "last-modified-date": {
+                                "value": 1523547712732
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "Above the weak nonlinearity: super-nonlinear waves in astrophysical and laboratory plasmas"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2018RvMPP...2....2D",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1007/s41614-018-0014-9",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/921989",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1523547713357
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1038/s41467-018-02950-5",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2018NatCo...9..508L",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 922041,
+                            "created-date": {
+                                "value": 1523547713357
+                            },
+                            "last-modified-date": {
+                                "value": 1523547713357
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "Acetylation accumulates PFKFB3 in cytoplasm to promote glycolysis and protects cells from cisplatin-induced apoptosis"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2018NatCo...9..508L",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1038/s41467-018-02950-5",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/922041",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1523547713347
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2018NatCo...9..520H",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1038/s41467-018-02970-1",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 922040,
+                            "created-date": {
+                                "value": 1523547713347
+                            },
+                            "last-modified-date": {
+                                "value": 1523547713347
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "Afforestation neutralizes soil pH"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2018NatCo...9..520H",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1038/s41467-018-02970-1",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/922040",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1523547712842
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1038/s41598-018-20975-0",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 921995,
+                            "created-date": {
+                                "value": 1523547712842
+                            },
+                            "last-modified-date": {
+                                "value": 1523547712842
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "Spheroid-cultured human umbilical cord-derived mesenchymal stem cells attenuate hepatic ischemia-reperfusion injury in rats"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1038/s41598-018-20975-0",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/921995",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1533311166081
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "source-work-id",
+                                "external-id-value": "test",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 940767,
+                            "created-date": {
+                                "value": 1533224766067
+                            },
+                            "last-modified-date": {
+                                "value": 1533311166081
+                            },
+                            "source": {
+                                "source-orcid": {
+                                    "uri": "http://sandbox.orcid.org/0000-0001-8868-9743",
+                                    "path": "0000-0001-8868-9743",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-client-id": None,
+                                "source-name": {
+                                    "value": "Cecilia Payne"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "Test title"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "source-work-id",
+                                        "external-id-value": "test",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "1913"
+                                },
+                                "month": {
+                                    "value": "01"
+                                },
+                                "day": {
+                                    "value": "01"
+                                },
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/940767",
+                            "display-index": "1"
+                        },
+                    ]
+                },
+                {
+                    "last-modified-date": {
+                        "value": 1534175474505
+                    },
+                    "external-ids": {
+                        "external-id": []
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 941672,
+                            "created-date": {
+                                "value": 1534175474505
+                            },
+                            "last-modified-date": {
+                                "value": 1534175474505
+                            },
+                            "source": {
+                                "source-orcid": {
+                                    "uri": "http://sandbox.orcid.org/0000-0001-8868-9743",
+                                    "path": "0000-0001-8868-9743",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-client-id": None,
+                                "source-name": {
+                                    "value": "Cecilia Payne"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "0.8 - 2.5 micron Spectroscopy of V4633 Sagittarii (Nova Sagittarii 1998)"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": []
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": None,
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/941672",
+                            "display-index": "1"
+                        }
+                    ]
+                }
+            ],
+            "path": "/0000-0001-8868-9743/works"
+        },
+        "path": "/0000-0001-8868-9743/activities"
+    },
+    "path": "/0000-0001-8868-9743"
+}

--- a/orcid_service/tests/stubdata/orcid_profile_api_v2_personaldetails.py
+++ b/orcid_service/tests/stubdata/orcid_profile_api_v2_personaldetails.py
@@ -1,0 +1,30 @@
+data = {
+    "last-modified-date": {
+        "value": 1523547463983
+    },
+    "name": {
+        "created-date": {
+            "value": 1523547463758
+        },
+        "last-modified-date": {
+            "value": 1523547463983
+        },
+        "given-names": {
+            "value": "Cecilia"
+        },
+        "family-name": {
+            "value": "Payne"
+        },
+        "credit-name": None,
+        "source": None,
+        "visibility": "PUBLIC",
+        "path": "0000-0001-8868-9743"
+    },
+    "other-names": {
+        "last-modified-date": None,
+        "other-name": [],
+        "path": "/0000-0001-8868-9743/other-names"
+    },
+    "biography": None,
+    "path": "/0000-0001-8868-9743/personal-details"
+}

--- a/orcid_service/tests/stubdata/orcid_profile_api_v2_short.py
+++ b/orcid_service/tests/stubdata/orcid_profile_api_v2_short.py
@@ -1,0 +1,194 @@
+data = {
+    "orcid-identifier": {
+        "uri": "http://sandbox.orcid.org/0000-0001-8868-9743",
+        "path": "0000-0001-8868-9743",
+        "host": "sandbox.orcid.org"
+    },
+    "preferences": {
+        "locale": "EN"
+    },
+    "history": {
+        "creation-method": "MEMBER_REFERRED",
+        "completion-date": None,
+        "submission-date": {
+            "value": 1523547463758
+        },
+        "last-modified-date": {
+            "value": 1534367410146
+        },
+        "claimed": True,
+        "source": None,
+        "deactivation-date": None,
+        "verified-email": True,
+        "verified-primary-email": True
+    },
+    "person": {
+        "last-modified-date": None,
+        "name": {
+            "created-date": {
+                "value": 1523547463758
+            },
+            "last-modified-date": {
+                "value": 1523547463983
+            },
+            "given-names": {
+                "value": "Cecilia"
+            },
+            "family-name": {
+                "value": "Payne"
+            },
+            "credit-name": None,
+            "source": None,
+            "visibility": "PUBLIC",
+            "path": "0000-0001-8868-9743"
+        },
+        "other-names": {
+            "last-modified-date": None,
+            "other-name": [],
+            "path": "/0000-0001-8868-9743/other-names"
+        },
+        "biography": None,
+        "researcher-urls": {
+            "last-modified-date": None,
+            "researcher-url": [],
+            "path": "/0000-0001-8868-9743/researcher-urls"
+        },
+        "emails": {
+            "last-modified-date": None,
+            "email": [],
+            "path": "/0000-0001-8868-9743/email"
+        },
+        "addresses": {
+            "last-modified-date": None,
+            "address": [],
+            "path": "/0000-0001-8868-9743/address"
+        },
+        "keywords": {
+            "last-modified-date": None,
+            "keyword": [],
+            "path": "/0000-0001-8868-9743/keywords"
+        },
+        "external-identifiers": {
+            "last-modified-date": None,
+            "external-identifier": [],
+            "path": "/0000-0001-8868-9743/external-identifiers"
+        },
+        "path": "/0000-0001-8868-9743/person"
+    },
+    "activities-summary": {
+        "last-modified-date": {
+            "value": 1534367390880
+        },
+        "educations": {
+            "last-modified-date": None,
+            "education-summary": [],
+            "path": "/0000-0001-8868-9743/educations"
+        },
+        "employments": {
+            "last-modified-date": None,
+            "employment-summary": [],
+            "path": "/0000-0001-8868-9743/employments"
+        },
+        "fundings": {
+            "last-modified-date": None,
+            "group": [],
+            "path": "/0000-0001-8868-9743/fundings"
+        },
+        "peer-reviews": {
+            "last-modified-date": None,
+            "group": [],
+            "path": "/0000-0001-8868-9743/peer-reviews"
+        },
+        "works": {
+            "last-modified-date": {
+                "value": 1534367390880
+            },
+            "group": [
+                {
+                    "last-modified-date": {
+                        "value": 1523547712899
+                    },
+                    "external-ids": {
+                        "external-id": [
+                            {
+                                "external-id-type": "doi",
+                                "external-id-value": "10.1038/s41598-018-20787-2",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            },
+                            {
+                                "external-id-type": "bibcode",
+                                "external-id-value": "2018NatSR...8.2398L",
+                                "external-id-url": None,
+                                "external-id-relationship": "SELF"
+                            }
+                        ]
+                    },
+                    "work-summary": [
+                        {
+                            "put-code": 922001,
+                            "created-date": {
+                                "value": 1523547712899
+                            },
+                            "last-modified-date": {
+                                "value": 1523547712899
+                            },
+                            "source": {
+                                "source-orcid": None,
+                                "source-client-id": {
+                                    "uri": "http://sandbox.orcid.org/client/APP-P5ANJTQRRTMA6GXZ",
+                                    "path": "APP-P5ANJTQRRTMA6GXZ",
+                                    "host": "sandbox.orcid.org"
+                                },
+                                "source-name": {
+                                    "value": "NASA Astrophysics Data System"
+                                }
+                            },
+                            "title": {
+                                "title": {
+                                    "value": "A novel small deletion in the NHS gene associated with Nance-Horan syndrome"
+                                },
+                                "subtitle": None,
+                                "translated-title": None
+                            },
+                            "external-ids": {
+                                "external-id": [
+                                    {
+                                        "external-id-type": "bibcode",
+                                        "external-id-value": "2018NatSR...8.2398L",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    },
+                                    {
+                                        "external-id-type": "doi",
+                                        "external-id-value": "10.1038/s41598-018-20787-2",
+                                        "external-id-url": None,
+                                        "external-id-relationship": "SELF"
+                                    }
+                                ]
+                            },
+                            "type": "JOURNAL_ARTICLE",
+                            "publication-date": {
+                                "year": {
+                                    "value": "2018"
+                                },
+                                "month": {
+                                    "value": "12"
+                                },
+                                "day": None,
+                                "media-type": None
+                            },
+                            "visibility": "PUBLIC",
+                            "path": "/0000-0001-8868-9743/work/922001",
+                            "display-index": "0"
+                        }
+                    ]
+                },
+
+            ],
+            "path": "/0000-0001-8868-9743/works"
+        },
+        "path": "/0000-0001-8868-9743/activities"
+    },
+    "path": "/0000-0001-8868-9743"
+}

--- a/orcid_service/tests/test_advertise.py
+++ b/orcid_service/tests/test_advertise.py
@@ -1,14 +1,15 @@
-from flask.ext.testing import TestCase
 import unittest
 from orcid_service import app
+from orcid_service.tests.base import TestCaseDatabase
 
 
-class TestWebservices(TestCase):
+class TestWebservices(TestCaseDatabase):
     '''Tests that each route is an http response'''
+
     def create_app(self):
         '''Start the wsgi application'''
         a = app.create_app(**{
-            'SQLALCHEMY_DATABASE_URI': 'sqlite:///'
+            'SQLALCHEMY_DATABASE_URI': self.postgresql_url
            })
         return a
 

--- a/orcid_service/tests/test_service.py
+++ b/orcid_service/tests/test_service.py
@@ -97,24 +97,25 @@ class TestServices(TestCaseDatabase):
             content_type='application/json',
             body=request_callback)
 
-        r = self.client.get('/0000-0001-8868-9743/orcid-profile/simple',
+        r = self.client.get('/0000-0001-8868-9743/orcid-profile/simple?update=True',
                 headers={'Orcid-Authorization': 'secret'})
 
         self.assertStatus(r, 200)
-        self.assertEquals(len(r.json), 6)
+        self.assertEquals(len(r.json), 7)
 
         s = self.client.get('/0000-0001-8868-9743/orcid-profile/full',
                 headers={'Orcid-Authorization': 'secret'})
 
         self.assertStatus(s, 200)
-        self.assertEquals(len(s.json), 8)
+        self.assertEquals(len(s.json), 9)
+        self.assertEquals(len(s.json['2015ApJ...810..149L']['source']),2)
 
         httpretty.register_uri(
             httpretty.GET, self.app.config['ORCID_API_ENDPOINT'] + '/0000-0001-8868-9743/record',
             content_type='application/json',
             body=request_second_callback)
 
-        f = self.client.get('/0000-0001-8868-9743/orcid-profile/simple?update=True',
+        f = self.client.get('/0000-0001-8868-9743/orcid-profile/full?update=True',
                             headers={'Orcid-Authorization': 'secret'})
 
         self.assertStatus(f, 200)

--- a/orcid_service/tests/test_service.py
+++ b/orcid_service/tests/test_service.py
@@ -77,9 +77,6 @@ class TestServices(TestCaseDatabase):
 
             if request.method == 'GET':
                 return (200, headers, json.dumps(orcid_profile_api_v2.data))
-            elif request.method == 'POST':
-                assert request.body == json.dumps({'foo': 'bar'})
-                return (201, headers, '')  # orcid literally returns empty string
 
         def request_second_callback(request, uri, headers):
             assert request.headers['Accept'] == 'application/json'
@@ -90,10 +87,6 @@ class TestServices(TestCaseDatabase):
 
         httpretty.register_uri(
             httpretty.GET, self.app.config['ORCID_API_ENDPOINT'] + '/0000-0001-8868-9743/record',
-            content_type='application/json',
-            body=request_callback)
-        httpretty.register_uri(
-            httpretty.POST, self.app.config['ORCID_API_ENDPOINT'] + '/0000-0001-8868-9743/record',
             content_type='application/json',
             body=request_callback)
 

--- a/orcid_service/views.py
+++ b/orcid_service/views.py
@@ -341,6 +341,19 @@ def update_status(orcid_id):
 
         return json.dumps(records), 200
 
+@advertise(scopes=[], rate_limit = [100, 3600*24])
+@bp.route('/orcid-name/<orcid_id>', methods=['GET'])
+def orcid_name(orcid_id):
+    '''Get name from ORCID profile'''
+
+    payload, headers = check_request(request)
+
+    r = current_app.client.get(current_app.config['ORCID_API_ENDPOINT'] + '/' + orcid_id + '/personal-details',
+                                   headers=headers)
+
+    return r.text, r.status_code
+
+
 def update_profile(orcid_id, data=None):
     """Inserts data into the user record and updates the 'updated'
     column with the most recent timestamp"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.13
+git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.15
 alembic==0.9.2
 psycopg2==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.6
+git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.13
 alembic==0.9.2
-Flask==0.12.2
-flask-consulate==0.1.2
-flask-discoverer==0.0.2
 psycopg2==2.7.1
-SQLAlchemy-Utils==0.32.14
-requests==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/adsabs/ADSMicroserviceUtils.git@v1.0.15
 alembic==0.9.2
 psycopg2==2.7.1
+SQLAlchemy-Utils==0.32.14


### PR DESCRIPTION
New endpoints:
For retrieving/updating parsed profile in local storage:
* /<orcid-id>/orcid-profile/simple
* /<orcid-id>/orcid-profile/full
For updating the verification status of records (to be used by the pipeline):
* /update-status/<orcid-id>

New table:
* profile